### PR TITLE
Add bin/cue extensions for PCE-TurboGrafx and Sega Genesis

### DIFF
--- a/FunKey/board/funkey/rootfs-overlay/usr/games/collections/Game Boy Advance/settings.conf
+++ b/FunKey/board/funkey/rootfs-overlay/usr/games/collections/Game Boy Advance/settings.conf
@@ -1,7 +1,7 @@
 # Uncomment and edit the following line to use a different ROM path.
 list.path = %BASE_ITEM_PATH%/%ITEM_COLLECTION_NAME%
 list.includeMissingItems = false
-list.extensions = gba,GBA
+list.extensions = gba,GBA,zip,ZIP
 list.menuSort = yes
 
 launcher = gba

--- a/FunKey/board/funkey/rootfs-overlay/usr/games/collections/NES/settings.conf
+++ b/FunKey/board/funkey/rootfs-overlay/usr/games/collections/NES/settings.conf
@@ -1,7 +1,7 @@
 # Uncomment and edit the following line to use a different ROM path.
 list.path = %BASE_ITEM_PATH%/%ITEM_COLLECTION_NAME%
 list.includeMissingItems = false
-list.extensions = nes,NES,fds,FDS
+list.extensions = nes,NES,fds,FDS,zip,ZIP
 list.menuSort = yes
 
 launcher = NES

--- a/FunKey/board/funkey/rootfs-overlay/usr/games/collections/PCE-TurboGrafx/settings.conf
+++ b/FunKey/board/funkey/rootfs-overlay/usr/games/collections/PCE-TurboGrafx/settings.conf
@@ -1,7 +1,7 @@
 # Uncomment and edit the following line to use a different ROM path.
 list.path = %BASE_ITEM_PATH%/%ITEM_COLLECTION_NAME%
 list.includeMissingItems = false
-list.extensions = zip,ZIP,pce,PCE,sgx,SGX
+list.extensions = zip,ZIP,pce,PCE,sgx,SGX,bin,BIN,cue,CUE
 list.menuSort = yes
 
 launcher = pce

--- a/FunKey/board/funkey/rootfs-overlay/usr/games/collections/PCE-TurboGrafx/settings.conf
+++ b/FunKey/board/funkey/rootfs-overlay/usr/games/collections/PCE-TurboGrafx/settings.conf
@@ -1,7 +1,7 @@
 # Uncomment and edit the following line to use a different ROM path.
 list.path = %BASE_ITEM_PATH%/%ITEM_COLLECTION_NAME%
 list.includeMissingItems = false
-list.extensions = zip,ZIP,pce,PCE,sgx,SGX,bin,BIN,cue,CUE
+list.extensions = zip,ZIP,pce,PCE,sgx,SGX,cue,CUE
 list.menuSort = yes
 
 launcher = pce

--- a/FunKey/board/funkey/rootfs-overlay/usr/games/collections/SNES/settings.conf
+++ b/FunKey/board/funkey/rootfs-overlay/usr/games/collections/SNES/settings.conf
@@ -1,7 +1,7 @@
 # Uncomment and edit the following line to use a different ROM path.
 list.path = %BASE_ITEM_PATH%/%ITEM_COLLECTION_NAME%
 list.includeMissingItems = false
-list.extensions = sfc,SFC,smc,SMC
+list.extensions = sfc,SFC,smc,SMC,zip,ZIP
 list.menuSort = yes
 
 launcher = snes

--- a/FunKey/board/funkey/rootfs-overlay/usr/games/collections/Sega Genesis/settings.conf
+++ b/FunKey/board/funkey/rootfs-overlay/usr/games/collections/Sega Genesis/settings.conf
@@ -19,7 +19,7 @@ list.includeMissingItems = true
 ###############################################################################
 # Extensions are comma separated without spaces
 ###############################################################################
-list.extensions = zip,ZIP,md,MD,bin,BIN,smd,SMD
+list.extensions = zip,ZIP,md,MD,bin,BIN,smd,SMD,cue,CUE
 
 ###############################################################################
 # If a menu.xml file exists, it will display the menu alphabetically. To


### PR DESCRIPTION
Changes proposed in this pull request:
Adds `bin,BIN,cue,CUE` to Sega Genesis and PCE settings.confs for SegaCD and TurboGrafx-CD games since PicoDrive and Mednafen both support these extensions. 

@funkey-project/funkey-project-admins
