### PR TITLE
Enable *.gen extension for Genesis games

### DIFF
--- a/FunKey/board/funkey/rootfs-overlay/usr/games/collections/Sega Genesis/settings.conf
+++ b/FunKey/board/funkey/rootfs-overlay/usr/games/collections/Sega Genesis/settings.conf
@@ -19,7 +19,7 @@ list.includeMissingItems = true
 ###############################################################################
 # Extensions are comma separated without spaces
 ###############################################################################
-list.extensions = zip,ZIP,md,MD,bin,BIN,32x,32X,cue,CUE,cso,CSO,chd,CHD,smd,SMD
+list.extensions = zip,ZIP,md,MD,bin,BIN,32x,32X,cue,CUE,cso,CSO,chd,CHD,smd,SMD,gen,GEN
 
 ###############################################################################
 # If a menu.xml file exists, it will display the menu alphabetically. To


### PR DESCRIPTION
This extension is quite common for storing Genesis roms on the internets. I think it should be enabled.

Fixes # .

Changes proposed in this pull request:
- Enable *.gen / *.GEN extension for Mega Drive / Genesis roms

@funkey-project/funkey-project-admins
